### PR TITLE
Skipped translations in minimal (script-checker) mode

### DIFF
--- a/src/map/script.c
+++ b/src/map/script.c
@@ -4682,6 +4682,9 @@ void script_load_translations(void) {
 	int i, size;
 	uint32 total = 0;
 	uint8 lang_id = 0, k;
+
+	if (map->minimal) // No translations in minimal mode
+		return;
 	
 	script->translation_db = strdb_alloc(DB_OPT_DUP_KEY, NAME_LENGTH*2+1);
 	


### PR DESCRIPTION
- Translations aren't used in script-checker mode, so there is no point
  loading them.
- Fixes an error message caused by a missing default language when
  starting in script-checker mode.
- Special thanks to Ind, jaBote.

Signed-off-by: Haru <haru@dotalux.com>